### PR TITLE
fix infinite adding of MPVolumeView to the wrapper

### DIFF
--- a/IOS11VolumeViewTutorial/IOS11VolumeViewTutorial/ViewController.swift
+++ b/IOS11VolumeViewTutorial/IOS11VolumeViewTutorial/ViewController.swift
@@ -23,8 +23,10 @@ class ViewController: UIViewController {
         view.addSubview(wrapperView)
         
         // 3
-        let volumeView = MPVolumeView(frame: wrapperView.bounds)
-        wrapperView.addSubview(volumeView)
+        if wrapperView.subviews.count == 0 {
+            let volumeView = MPVolumeView(frame: wrapperView.bounds)
+            wrapperView.addSubview(volumeView)
+        }
     }
     
     @IBAction func stopSound(_ sender: Any) {


### PR DESCRIPTION
Before my edit:
po wrapperView.subviews
▿ 3 elements
  - 0 : <MPVolumeView: 0x106e00370; frame = (0 0; 300 20); opaque = NO; layer = <CALayer: 0x281acc0a0>>
  - 1 : <MPVolumeView: 0x106d09e40; frame = (0 0; 300 20); opaque = NO; layer = <CALayer: 0x281ae5960>>
  - 2 : <MPVolumeView: 0x106b066f0; frame = (0 0; 300 20); opaque = NO; layer = <CALayer: 0x281aca880>>